### PR TITLE
Add missing Vite config and entry files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
-# dg-board
+# Dungeon Game
 
-[Edit in StackBlitz next generation editor ⚡️](https://stackblitz.com/~/github.com/mikaelhadler/dg-board)
+This is a small React + Phaser project demonstrating a simple dungeon pathfinding game.
+The app is built with Vite and styled with Tailwind CSS.
+
+## Getting Started
+
+Install the dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+To create a production build run:
+
+```bash
+npm run build
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dungeon Game</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- add `index.html` and `src/main.tsx` so Vite can start
- provide `tsconfig.json` and `vite.config.ts`
- expand README with setup instructions

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6848481b571c832c88f2fc71a971564d